### PR TITLE
OS X Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,8 @@ for the [Toontown Rewritten](https://www.toontownrewritten.com/)
 Inspired by [Shticker Book
 Rewritten](https://github.com/madsciencecoder/Shticker-Book-Rewritten).
 
-Currently **only** built to support GNU/Linux and Windows NT (using the MSVC
-toolchain), because I don&rsquo;t know much about ~~Windows NT nor about~~
-macOS. If you know something about macOS and want to help out, feel very free
-to submit a PR or to file an issue with a description of what can be done to
-support the platform. Mostly I just don&rsquo;t have a macOS machine that I
-can test on.
+Currently builds and functions on GNU/Linux, Windows NT (using the MSVC
+toolchain), and OS X (Be sure to allow terminal the ability to monitor inputs).
 
 ## Installing
 
@@ -31,7 +27,7 @@ on GitHub.
 ### From [crates.io](https://crates.io/)
 
 Requires a distribution of [Rust](https://www.rust-lang.org/)/cargo, which you
-can get from [rustup](https://rustup.rs/).
+can get from [rustup](https://rustup.rs/). *OS X (and maybe others): If the build fails, try using the nightly branch of rust.*
 
 ```bash
 cargo install shticker_book_unwritten
@@ -47,7 +43,7 @@ cargo install -f shticker_book_unwritten
 ### From GitHub git repository
 
 Requires a distribution of [Rust](https://www.rust-lang.org/)/cargo, which you
-can get from [rustup](https://rustup.rs/).
+can get from [rustup](https://rustup.rs/). *OS X (and maybe others): If the build fails, try using the nightly branch of rust.*
 
 ```bash
 git clone https://github.com/JonathanHelianthicusDoe/shticker_book_unwritten.git

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,7 +71,7 @@ pub fn get_config(
         let config_path = if let Some(s) = config_path {
             PathBuf::from(s)
         } else {
-            #[cfg(unix)]
+            #[cfg(target_os = "linux")]
             {
                 let mut xdg_config_home = String::new();
                 let mut home = String::new();
@@ -116,6 +116,29 @@ pub fn get_config(
 
                 if !appdata.is_empty() {
                     [appdata.as_str(), crate_name!(), "config.json"]
+                        .iter()
+                        .collect()
+                } else {
+                    return Err(Error::NoPossibleConfigPath);
+                }
+            }
+            #[cfg(target_os = "macos")]
+            {
+                let mut home = String::new();
+
+                for (key, value) in env::vars() {
+                    match key.as_str() {
+                        "HOME" => home = value,
+                        _ =>
+                            if !(home.is_empty())
+                            {
+                                break;
+                            },
+                    }
+                }
+
+                if !home.is_empty() {
+                    [home.as_str(), "Library", "Preferences", crate_name!(), "config.json"]
                         .iter()
                         .collect()
                 } else {

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,13 +48,17 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::NoPossibleConfigPath => {
-                #[cfg(unix)]
+                #[cfg(target_os = "linux")]
                 const MSG: &str = "No config path was given, and the \
                                    $XDG_CONFIG_HOME and $HOME environment \
                                    variables are both unset or empty";
                 #[cfg(windows)]
                 const MSG: &str = "No config path was given, and the \
                                    %APPDATA% environment variable is unset \
+                                   or empty";
+                #[cfg(target_os = "macos")]
+                const MSG: &str = "No config path was given, and the \
+                                   $HOME environment variable is unset \
                                    or empty";
 
                 f.write_str(MSG)

--- a/src/login.rs
+++ b/src/login.rs
@@ -358,7 +358,7 @@ fn launch<S: AsRef<OsStr>, T: AsRef<OsStr>>(
         println!("Launching the game...");
     }
 
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     let command_text = "./TTREngine";
     #[cfg(windows)]
     let command_text = {
@@ -367,6 +367,15 @@ fn launch<S: AsRef<OsStr>, T: AsRef<OsStr>>(
         // that we are pointing at the right executable.
         let mut command_buf = config.install_dir.clone();
         command_buf.push("TTREngine.exe");
+
+        command_buf
+    };
+
+    #[cfg(target_os = "macos")]
+    let command_text = {
+        // `.current_dir` is also borked on OS X
+        let mut command_buf = config.install_dir.clone();
+        command_buf.push("Toontown Rewritten");
 
         command_buf
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
 }
 
 fn run() -> Result<(), Error> {
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     const CONFIG_LONG_HELP: &str = concat!(
         "Configuration JSON file to use. Defaults to \"$XDG_CONFIG_HOME\"/",
         crate_name!(),
@@ -42,6 +42,12 @@ fn run() -> Result<(), Error> {
         r"Configuration JSON file to use. Defaults to %APPDATA%\",
         crate_name!(),
         r"\config.json",
+    );
+    #[cfg(target_os = "macos")]
+    const CONFIG_LONG_HELP: &str = concat!(
+        r"Configuration JSON file to use. Defaults to $HOME/Library/Preferences/",
+        crate_name!(),
+        r"/config.json",
     );
 
     let arg_matches = App::new(crate_name!())


### PR DESCRIPTION
This PR adds the ability to build and run SBR on OS X. I've tested this on catalina and it works fine provided you allow terminal the ability to monitor keyboard inputs (new security stuff i guess).

Here's a binary if anybody wants to try it out: [shticker_book_unwritten_unstripped.zip](https://github.com/JonathanHelianthicusDoe/shticker_book_unwritten/files/3726524/shticker_book_unwritten_unstripped.zip)

If you want any changes made, I will gladly make and test them. I will be upfront with the fact that my rust knowledge is limited and most of the changes were made by looking at existing code and adapting them to OS X.
