### PR TITLE
Add freedesktop secret service support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "GPL-3.0-or-later"
 
 [features]
 default = []
-secret-store = ["secret-service"]
+secret-store = ["dep:secret-service"]
 
 [dependencies]
 bzip2 = "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ keywords = ["cli", "launcher", "ttr", "toontown", "rewritten"]
 categories = ["games"]
 license = "GPL-3.0-or-later"
 
+[features]
+default = []
+secret-store = ["secret-service"]
+
 [dependencies]
 bzip2 = "0.4.4"
 rpassword = "7.3.1"
@@ -35,6 +39,12 @@ features = [
 version = "0.12.1"
 default-features = false
 features = ["blocking", "rustls-tls"]
+
+[dependencies.secret-service]
+version = "5.0.0"
+optional = true
+default-features = false
+features = ["rt-tokio-crypto-rust"]
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ version = "0.12.1"
 default-features = false
 features = ["blocking", "rustls-tls"]
 
-[dependencies.secret-service]
+[target.'cfg(target_os = "linux")'.dependencies.secret-service]
 version = "5.0.0"
 optional = true
 default-features = false

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,4 +1,4 @@
-use crate::{config::Config, error::Error, keyring, login, update};
+use crate::{config::Config, error::Error, login, update};
 use clap::{crate_name, crate_version};
 use reqwest::blocking as rb;
 use std::{
@@ -383,7 +383,7 @@ fn display_accounts(
     #[cfg(not(all(target_os = "linux", feature = "secret-store")))]
     let stored_accounts: Vec<String> = vec![];
     #[cfg(all(target_os = "linux", feature = "secret-store"))]
-    let stored_accounts = keyring::stored_accounts()?;
+    let stored_accounts = crate::keyring::stored_accounts()?;
 
     let max_name_len = if let Some(l) = config
         .accounts

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,7 @@ pub struct Config {
 
 impl Config {
     /// Same return type as `BTreeMap::insert`.
+    #[cfg(not(all(target_os = "linux", feature = "secret-store")))]
     pub fn add_account(
         &mut self,
         username: String,
@@ -276,6 +277,7 @@ fn prompt_for_config_values<P: AsRef<Path>>(
     }
 }
 
+#[cfg(not(all(target_os = "linux", feature = "secret-store")))]
 pub fn commit_config<P: AsRef<Path>>(
     config: &Config,
     config_path: P,

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,6 +43,16 @@ pub enum Error {
     ThreadJoinError(io::Error),
     ProcessKillError(u32, io::Error),
     HashMismatch(PathBuf, [u8; 20]),
+    #[cfg(all(target_os = "linux", feature = "secret-store"))]
+    SessionStoreConnectError(secret_service::Error),
+    #[cfg(all(target_os = "linux", feature = "secret-store"))]
+    PasswordUnlockError(secret_service::Error),
+    #[cfg(all(target_os = "linux", feature = "secret-store"))]
+    PasswordGetError(secret_service::Error),
+    #[cfg(all(target_os = "linux", feature = "secret-store"))]
+    PasswordUtf8Error(std::string::FromUtf8Error),
+    #[cfg(all(target_os = "linux", feature = "secret-store"))]
+    PasswordSaveError(secret_service::Error),
 }
 
 impl fmt::Display for Error {
@@ -189,6 +199,46 @@ impl fmt::Display for Error {
 
                 Ok(())
             }
+            #[cfg(all(target_os = "linux", feature = "secret-store"))]
+            Self::SessionStoreConnectError(error) => {
+                write!(
+                    f,
+                    "Failed to connect to session password store:\n\t{}",
+                    error
+                )
+            }
+            #[cfg(all(target_os = "linux", feature = "secret-store"))]
+            Self::PasswordUnlockError(error) => {
+                write!(
+                    f,
+                    "Could not unlock password from session store:\n\t{}",
+                    error
+                )
+            }
+            #[cfg(all(target_os = "linux", feature = "secret-store"))]
+            Self::PasswordGetError(error) => {
+                write!(
+                    f,
+                    "Failed to get password from secret store:\n\t{}",
+                    error
+                )
+            }
+            #[cfg(all(target_os = "linux", feature = "secret-store"))]
+            Self::PasswordUtf8Error(error) => {
+                write!(
+                    f,
+                    "Password from session store is invalid:\n\t{}",
+                    error
+                )
+            }
+            #[cfg(all(target_os = "linux", feature = "secret-store"))]
+            Self::PasswordSaveError(error) => {
+                write!(
+                    f,
+                    "Failed to save password in session store:\n\t{}",
+                    error
+                )
+            }
         }
     }
 }
@@ -235,6 +285,16 @@ impl Error {
             Self::ThreadJoinError(_) => 35,
             Self::ProcessKillError(_, _) => 36,
             Self::HashMismatch(_, _) => 37,
+            #[cfg(all(target_os = "linux", feature = "secret-store"))]
+            Self::SessionStoreConnectError(_) => 38,
+            #[cfg(all(target_os = "linux", feature = "secret-store"))]
+            Self::PasswordUnlockError(_) => 39,
+            #[cfg(all(target_os = "linux", feature = "secret-store"))]
+            Self::PasswordGetError(_) => 40,
+            #[cfg(all(target_os = "linux", feature = "secret-store"))]
+            Self::PasswordUtf8Error(_) => 41,
+            #[cfg(all(target_os = "linux", feature = "secret-store"))]
+            Self::PasswordSaveError(_) => 42,
         }
     }
 }

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -1,0 +1,110 @@
+#![cfg(all(target_os = "linux", feature = "secret-store"))]
+
+use crate::{config::Config, error::Error};
+use secret_service::{blocking::SecretService, EncryptionType};
+use std::{collections::HashMap, path::Path};
+
+const APP_ID: &str = "app_id";
+const APP_ID_VALUE: &str = "shticker_book_unwritten";
+const SECRET_ITEM_LABEL: &str = "Toontown Credentials";
+const SECRET_ITEM_ATTRIBUTE: &str = "user";
+
+pub(super) fn get_saved_password(
+    _config: &Config,
+    username: &str,
+) -> Result<Option<String>, Error> {
+    let secret_service = SecretService::connect(EncryptionType::Dh)
+        .map_err(Error::SessionStoreConnectError)?;
+
+    let collection = secret_service
+        .get_default_collection()
+        .map_err(Error::SessionStoreConnectError)?;
+
+    collection
+        .ensure_unlocked()
+        .map_err(Error::PasswordUnlockError)?;
+
+    let mut results = collection
+        .search_items(HashMap::from([
+            (SECRET_ITEM_ATTRIBUTE, username),
+            (APP_ID, APP_ID_VALUE),
+        ]))
+        .map_err(Error::SessionStoreConnectError)?;
+
+    let Some(item) = results.pop() else {
+        return Ok(None);
+    };
+
+    item.ensure_unlocked().map_err(Error::PasswordUnlockError)?;
+
+    let secret = item.get_secret().map_err(Error::PasswordGetError)?;
+
+    Ok(Some(
+        String::from_utf8(secret).map_err(Error::PasswordUtf8Error)?,
+    ))
+}
+
+pub(super) fn save_password<P: AsRef<Path>>(
+    _config: &mut Config,
+    _config_path: P,
+    username: String,
+    password: String,
+) -> Result<(), Error> {
+    let secret_service = SecretService::connect(EncryptionType::Dh)
+        .map_err(Error::SessionStoreConnectError)?;
+
+    let collection = secret_service
+        .get_default_collection()
+        .map_err(Error::SessionStoreConnectError)?;
+
+    collection
+        .ensure_unlocked()
+        .map_err(Error::PasswordUnlockError)?;
+
+    collection
+        .create_item(
+            SECRET_ITEM_LABEL,
+            HashMap::from([
+                (SECRET_ITEM_ATTRIBUTE, username.as_str()),
+                (APP_ID, APP_ID_VALUE),
+            ]),
+            password.as_bytes(),
+            true, // replace
+            "text/plain",
+        )
+        .map_err(Error::PasswordSaveError)?;
+
+    Ok(())
+}
+
+pub(super) fn stored_accounts() -> Result<Vec<String>, Error> {
+    let secret_service = SecretService::connect(EncryptionType::Dh)
+        .map_err(Error::SessionStoreConnectError)?;
+
+    let collection = secret_service
+        .get_default_collection()
+        .map_err(Error::SessionStoreConnectError)?;
+
+    collection
+        .ensure_unlocked()
+        .map_err(Error::PasswordUnlockError)?;
+
+    let results = collection
+        .search_items(HashMap::from([(APP_ID, APP_ID_VALUE)]))
+        .map_err(Error::SessionStoreConnectError)?;
+
+    results
+        .into_iter()
+        .map(|item| {
+            item.ensure_unlocked().map_err(Error::PasswordUnlockError)?;
+
+            let attributes =
+                item.get_attributes().map_err(Error::PasswordGetError)?;
+
+            let username = attributes.get(SECRET_ITEM_ATTRIBUTE).cloned();
+
+            Ok(username)
+        })
+        .filter_map(|res| res.transpose())
+        .collect()
+}

--- a/src/login.rs
+++ b/src/login.rs
@@ -151,6 +151,10 @@ pub fn login<'a, P: AsRef<Path>, A: Iterator<Item = &'a str>>(
     if !usernames.is_empty() {
         for username in usernames {
             if let Some(password) = get_saved_password(config, username)? {
+                if !quiet {
+                    println!("Using saved password...");
+                }
+
                 handle_name_and_pw(
                     config,
                     config_path.as_ref(),
@@ -190,6 +194,10 @@ pub fn login<'a, P: AsRef<Path>, A: Iterator<Item = &'a str>>(
         let password = if let Some(password) =
             get_saved_password(config, &username_buf)?
         {
+            if !quiet {
+                println!("Using saved password...");
+            }
+
             password
         } else {
             print!("Password for {}: ", username_buf);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 mod command;
 mod config;
 mod error;
+mod keyring;
 mod login;
 mod patch;
 mod update;


### PR DESCRIPTION
This adds an optional feature to enable the use of the freedesktop secret service on linux. This means that shticker_book_unwritten no longer needs to keep passwords in plaintext.

tested on NixOS with the gnome keyring